### PR TITLE
Improved window focus tracking + bugfix on some systems 

### DIFF
--- a/plugins/dynamic/lastconfig.json
+++ b/plugins/dynamic/lastconfig.json
@@ -1,3 +1,3 @@
 {
-
+    "layer_count": 1
 }

--- a/plugins/dynamic/lastconfig.json
+++ b/plugins/dynamic/lastconfig.json
@@ -1,3 +1,3 @@
 {
-    "layer_count": 1
+
 }

--- a/plugins/plugin.py
+++ b/plugins/plugin.py
@@ -374,15 +374,6 @@ class CoilGeneratorUI(wx.Frame):
 def get_safe_name(name, keepcharacters = (' ','.','_')):
     return "".join(c for c in name if c.isalnum() or c in keepcharacters).rstrip()
 
-# use this class to track the last focused page
-class FocusTracker(wx.EvtHandler):
-	def __init__(self):
-		wx.EvtHandler.__init__(self)
-		self.prev_focused_window = None
-
-	def OnFocus(self, event):
-		self.prev_focused_window = event.GetEventObject()
-
 # Plugin definition
 class Plugin(pcbnew.ActionPlugin):
 	def __init__(self):
@@ -393,12 +384,8 @@ class Plugin(pcbnew.ActionPlugin):
 		self.show_toolbar_button = True
 		self.icon_file_name = os.path.join(os.path.dirname(__file__), 'icon.png')
 		self.dark_icon_file_name = os.path.join(os.path.dirname(__file__), 'icon.png')
-
-		self.focus_tracker = FocusTracker()
-
-		# if a window loses focus, this event updates the last focused window
-		for window in wx.GetTopLevelWindows():
-			window.Bind(wx.EVT_SET_FOCUS, self.focus_tracker.OnFocus)
 			
 	def Run(self):
-		CoilGeneratorUI(self.focus_tracker.prev_focused_window).Show()
+		# Assuming the PCBNew window is focussed when run function is executed
+		# Alternative would be to keep track of last focussed window, which does not seem to work on all systems
+		CoilGeneratorUI(wx.Window.FindFocus()).Show()

--- a/plugins/plugin.py
+++ b/plugins/plugin.py
@@ -386,6 +386,6 @@ class Plugin(pcbnew.ActionPlugin):
 		self.dark_icon_file_name = os.path.join(os.path.dirname(__file__), 'icon.png')
 			
 	def Run(self):
-		# Assuming the PCBNew window is focussed when run function is executed
+		# Assuming the PCBNew window is focused when run function is executed
 		# Alternative would be to keep track of last focussed window, which does not seem to work on all systems
 		CoilGeneratorUI(wx.Window.FindFocus()).Show()


### PR DESCRIPTION
# What this does

- Removes the Window Focus tracker and instead tracks the currently focused window via more direct wx functions
- Implements a possible bugfix where EVT_SET_FOCUS event does not seem to be delivered on some systems and pasting the generated coil is not possible

# About the bugfix

I am currently running a ```wxPython  '4.2.0 gtk3 (phoenix) wxWidgets 3.2.1' ``` instance on ```Ubuntu 22.04.2 LTS```.
When generating a coil, the coil object is not pasted into PCBNew automatically by the plugin. However, pressing Ctrl+V manually, one can place the coil into PCBNew.
I noticed that the plugin tracks the active window via an ```EVT_SET_FOCUS``` event handler, which it then uses to paste the generated coil into PCBNew. This event handler does not seem to be called at all on the above mentioned system.
By removing the manual Window Focus tracking and instead using the more direct wx function ```FindFocus()```, the automated pasting of the coil object works again and further should deliver more reliable results on other systems.