### PR TITLE
Rewrite of Generator Code, Support for N layers, UI enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ _(Footprint automatically exported can be viewed in the footprint editor)_
 
 ## Future Goals
 
-- [ ] Rewrite of the generator code, as it is currently based on a two layer implementation that was only extended for 4 layers
-- [ ] Add more layer support
 - [ ] Add support for stretched coils
 - [ ] Add support for rectangular coils
 - [ ] Display coil statistics in the UI, [similar to TI's implementation](https://webench.ti.com/wb5/LDC)

--- a/plugins/dynamic/lastconfig.json
+++ b/plugins/dynamic/lastconfig.json
@@ -1,3 +1,10 @@
 {
-
+    "layer_count": 6,
+    "turn_direction": 0,
+    "turns_count": "1",
+    "outer_diameter": "20.0",
+    "trace_width": "3.27",
+    "via_outer": "0.9",
+    "via_drill": "0.4",
+    "trace_spacing": "0.327"
 }

--- a/plugins/dynamic/lastconfig.json
+++ b/plugins/dynamic/lastconfig.json
@@ -1,10 +1,3 @@
 {
-    "layer_count": 5,
-    "turn_direction": 0,
-    "turns_count": "1",
-    "outer_diameter": "20.0",
-    "trace_width": "0.327",
-    "via_outer": "0.9",
-    "via_drill": "0.4",
-    "trace_spacing": "0.127"
+
 }

--- a/plugins/dynamic/lastconfig.json
+++ b/plugins/dynamic/lastconfig.json
@@ -1,10 +1,10 @@
 {
-    "layer_count": 6,
+    "layer_count": 5,
     "turn_direction": 0,
     "turns_count": "1",
     "outer_diameter": "20.0",
-    "trace_width": "3.27",
+    "trace_width": "0.327",
     "via_outer": "0.9",
     "via_drill": "0.4",
-    "trace_spacing": "0.327"
+    "trace_spacing": "0.127"
 }

--- a/plugins/lib/coilgenerator.py
+++ b/plugins/lib/coilgenerator.py
@@ -262,7 +262,7 @@ def generate_pads(lines, outer_radius, trace_width, via_diameter, clockwise, lay
 	lines.append(
 		generator.line(
 			generator.P2D(outer_radius, top_pad_center_point.y),
-			top_pad_center_point,
+			generator.P2D(top_pad_center_point.x - 3 * trace_width, top_pad_center_point.y),
 			trace_width,
 			top_layer_name
 		)
@@ -282,7 +282,7 @@ def generate_pads(lines, outer_radius, trace_width, via_diameter, clockwise, lay
 		lines.append(
 			generator.line(
 				generator.P2D(outer_radius, bottom_pad_center_point.y),
-				bottom_pad_center_point,
+				generator.P2D(bottom_pad_center_point.x - 3 * trace_width, bottom_pad_center_point.y),
 				trace_width,
 				bottom_layer_name
 			)

--- a/plugins/lib/coilgenerator.py
+++ b/plugins/lib/coilgenerator.py
@@ -246,8 +246,8 @@ def generate_pads(lines, outer_radius, trace_width, via_diameter, clockwise, lay
 	wrap_direction_multiplier = 1 if clockwise else -1
 
 	#calculate pad center points
-	top_pad_center_point = generator.P2D(outer_radius + BREAKOUT_LEN + 4 * trace_width, (BREAKOUT_LEN + 0.5 * via_diameter) * -wrap_direction_multiplier)
-	bottom_pad_center_point = generator.P2D(outer_radius + BREAKOUT_LEN + 4 * trace_width, (BREAKOUT_LEN + 0.5 * via_diameter)* wrap_direction_multiplier)
+	top_pad_center_point = generator.P2D(outer_radius + BREAKOUT_LEN + 4 * trace_width, (BREAKOUT_LEN + 0.5 * via_diameter + trace_width) * -wrap_direction_multiplier)
+	bottom_pad_center_point = generator.P2D(outer_radius + BREAKOUT_LEN + 4 * trace_width, (BREAKOUT_LEN + 0.5 * via_diameter + trace_width)* wrap_direction_multiplier)
 
 	# draw lines from coil spiral end point to top pad
 	lines.append(

--- a/plugins/lib/coilgenerator.py
+++ b/plugins/lib/coilgenerator.py
@@ -62,19 +62,15 @@ def generate(layer_count, wrap_clockwise, turns_per_layer, trace_width, trace_sp
 	lines = []
 	pads = []
 
-	VIA_INSIDE_RADIUS = outer_diameter / 2 - turns_per_layer * trace_width - (turns_per_layer -1) * trace_spacing - via_diameter - (trace_width + trace_spacing)
-	VIA_OUTSIDE_RADIUS = outer_diameter / 2 + via_diameter + 2 * trace_spacing + trace_width
+
+	(VIA_INSIDE_RADIUS, VIA_OUTSIDE_RADIUS) = get_via_radius(outer_diameter, turns_per_layer, trace_width, trace_spacing, via_diameter)
 
 	#calculate the number of vias inside and outside of coil and their corresponding degree spacing
 	num_vias_inside = 0
 	num_vias_outside = 0
 
 	if layer_count -1 > 0:
-		num_vias_inside = (layer_count -1) // 2
-		num_vias_outside = num_vias_inside
-		if (layer_count -1) % 2 != 0:
-			num_vias_inside += 1
-
+		(num_vias_inside, num_vias_outside) = get_num_vias(layer_count)
 
 		degree_steps_inside = 360 / (num_vias_inside)
 		degree_steps_outside = 0
@@ -257,6 +253,41 @@ def generate(layer_count, wrap_clockwise, turns_per_layer, trace_width, trace_sp
 	}
 
 	return template.format(**substitution_dict)
+
+def get_num_vias(layer_count):
+	"""
+	Calculates number of vias required inside and outside of coil
+	Args:
+		layer_count: Number of layers in coil
+
+	Returns:
+		(float, float): (Via inside of coil, Via outside of coil)
+	"""
+	num_vias_inside = (layer_count -1) // 2
+	num_vias_outside = num_vias_inside
+	if (layer_count -1) % 2 != 0:
+		num_vias_inside += 1
+
+	return (num_vias_inside, num_vias_outside)
+
+def get_via_radius(outer_diameter, turns_per_layer, trace_width, trace_spacing, via_diameter):
+	"""
+	Calculates diameter at which vias need to be placed
+	Args:
+		outer_diameter: Desires outer coil diameter. Coil generation is from outside to inside, so if this is too small, coil wraps may collode
+		turns_per_layer: Minimum number of turns per layer: Connecting to vias might introduce up to one more turn
+		trace_width: Width of line trace
+		trace_spacing: Distance between line traces
+		via_diameter: Outer diameter of connecting vias
+
+	Returns:
+		(float, float): (Via inside radius, Via outside radius)
+	"""
+	VIA_INSIDE_RADIUS = outer_diameter / 2 - turns_per_layer * trace_width - (turns_per_layer -1) * trace_spacing - via_diameter - (trace_width + trace_spacing)
+	VIA_OUTSIDE_RADIUS = outer_diameter / 2 + via_diameter + 2 * trace_spacing + trace_width
+
+	return (VIA_INSIDE_RADIUS, VIA_OUTSIDE_RADIUS)
+
 
 def get_circle_section_centerpoint(point_a, point_b, radius):
 	"""

--- a/plugins/lib/coilgenerator.py
+++ b/plugins/lib/coilgenerator.py
@@ -28,7 +28,18 @@ LAYER_INNER = ["In1.Cu", "In2.Cu"]
 
 BREAKOUT_LEN = 0.5  # (mm)
 
-def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, VIA_DIAMETER, VIA_DRILL, OUTER_DIAMETER, NAME):
+def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, VIA_DIAMETER, VIA_DRILL, OUTER_DIAMETER, NAME, layer_names):
+	class Connector:
+		x: float
+		y: float
+		angle: float
+
+		def __init__(self, x, y, angle):
+			self.x = x
+			self.y = y
+			self.angle = angle
+			self
+
 	template_file = os.path.join(os.path.dirname(__file__), TEMPLATE_FILE)
 
 	with open(template_file, "r") as file:
@@ -57,6 +68,8 @@ def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, V
 		if num_vias_outside != 0:
 			degree_steps_outside = 360 / (num_vias_outside)
 
+	arc_connectors = []
+
 	# generating layer - 1 vias
 	for v in range(0, LAYER_COUNT-1):
 
@@ -78,6 +91,8 @@ def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, V
 		if rotation_degree > 90 and rotation_degree < 270:
 			width *= -1
 
+		arc_connectors.append(Connector(width, height, rotation_degree))
+
 		vias.append(
 			generator.via(
 				generator.P2D(width, height),
@@ -86,192 +101,43 @@ def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, V
 			)
 		)
 
-	current_radius = OUTER_DIAMETER / 2 - N_TURNS * TRACE_WIDTH - (N_TURNS - 1) * TRACE_SPACING
-
-
 	# build out arcs to spec, until # turns is reached
-	wrap_multiplier = 1 if WRAP_CLOCKWISE else -1
+	wrap_direction_multiplier = 1 if WRAP_CLOCKWISE else -1
 	increment = TRACE_WIDTH + TRACE_SPACING
 
-	for arc in range(N_TURNS):
-		if arc == 0:
-			# Front Layer
-			arcs.extend(generator.arc(
-				generator.P2D(current_radius - VIA_DIAMETER, 0),
-				generator.P2D(-VIA_DIAMETER, -wrap_multiplier * (current_radius - VIA_DIAMETER / 2)),
-				generator.P2D(-current_radius, 0),
-				TRACE_WIDTH,
-				LAYER_TOP,
-				bool(wrap_multiplier + 1)
-			))
-			arcs.extend(generator.arc(
-				generator.P2D(-current_radius, 0),
-				generator.P2D(-increment / 2, wrap_multiplier * (current_radius + increment / 2)),
-				generator.P2D(current_radius + increment, 0),
-				TRACE_WIDTH,
-				LAYER_TOP,
-				bool(wrap_multiplier + 1)
-			))
+	start_radius = OUTER_DIAMETER / 2 - N_TURNS * TRACE_WIDTH - (N_TURNS - 1) * TRACE_SPACING
+	for layer in range(LAYER_COUNT):
+		current_radius = start_radius
 
-			if LAYER_COUNT > 1:
-				layer = LAYER_BOTTOM # top to bottom if 2 layers
+		# for odd layers, the wrap direction needs to be flipped
+		inverse_turn_mult = 1
+		if layer % 2 != 0:
+			inverse_turn_mult = -1
 
-				if LAYER_COUNT > 2:
-					layer = LAYER_INNER[0] # top to inner1 if more than two layers
-
-				arcs.extend(generator.arc(
-					generator.P2D(current_radius - VIA_DIAMETER, 0),
-					generator.P2D(-VIA_DIAMETER, wrap_multiplier * (current_radius - VIA_DIAMETER / 2)),
-					generator.P2D(-current_radius, 0),
-					TRACE_WIDTH,
-					layer,
-					not bool(wrap_multiplier + 1)
-				))
-				arcs.extend(generator.arc(
-					generator.P2D(-current_radius, 0),
-					generator.P2D(-increment / 2, -wrap_multiplier * (current_radius + increment / 2)),
-					generator.P2D(current_radius + increment, 0),
-					TRACE_WIDTH,
-					layer,
-					not bool(wrap_multiplier + 1)
-				))
-
-			if LAYER_COUNT > 2:
-				arcs.extend(generator.loop(
-					current_radius,
-					increment,
-					TRACE_WIDTH,
-					LAYER_INNER[1],
-					wrap_multiplier
-				))
-				arcs.extend(generator.arc(
-					generator.P2D(current_radius, 0),
-					generator.P2D(VIA_DIAMETER, wrap_multiplier * (current_radius - VIA_DIAMETER / 2)),
-					generator.P2D(-current_radius + VIA_DIAMETER, 0),
-					TRACE_WIDTH,
-					LAYER_INNER[1],
-					not bool(wrap_multiplier + 1)
-				))
-
-				arcs.extend(generator.loop(
-					current_radius,
-					increment,
-					TRACE_WIDTH,
-					LAYER_BOTTOM,
-					-wrap_multiplier
-				))
-				arcs.extend(generator.arc(
-					generator.P2D(current_radius, 0),
-					generator.P2D(VIA_DIAMETER, -wrap_multiplier * (current_radius - VIA_DIAMETER / 2)),
-					generator.P2D(-current_radius + VIA_DIAMETER, 0),
-					TRACE_WIDTH,
-					LAYER_BOTTOM,
-					bool(wrap_multiplier + 1)
-				))
-
-		elif arc == N_TURNS - 1 and LAYER_COUNT > 2:
-			# inner layer 0 extended lines
-			arcs.extend(generator.arc(
-				generator.P2D(OUTER_DIAMETER / 2 + VIA_DIAMETER + TRACE_SPACING, 0),
-				generator.P2D(VIA_DIAMETER + TRACE_SPACING, -wrap_multiplier * (OUTER_DIAMETER / 2 + (VIA_DIAMETER + TRACE_SPACING) / 2 - TRACE_WIDTH)),
-				generator.P2D(-(OUTER_DIAMETER - TRACE_WIDTH - TRACE_SPACING) / 2, 0),
-				TRACE_WIDTH,
-				LAYER_INNER[0],
-				bool(wrap_multiplier + 1)
-			))
-			arcs.extend(generator.arc(
-				generator.P2D(-(OUTER_DIAMETER - TRACE_WIDTH - TRACE_SPACING) / 2, 0),
-				generator.P2D(VIA_DIAMETER + TRACE_SPACING, wrap_multiplier * (OUTER_DIAMETER / 2 - (TRACE_WIDTH + TRACE_SPACING) / 2)),
-				generator.P2D((OUTER_DIAMETER - TRACE_WIDTH - TRACE_SPACING) / 2, 0),
-				TRACE_WIDTH,
-				LAYER_INNER[0],
-				bool(wrap_multiplier + 1)
-			))
-
-			# inner layer 1 extended lines
-			arcs.extend(generator.arc(
-				generator.P2D(OUTER_DIAMETER / 2 + VIA_DIAMETER + TRACE_SPACING, 0),
-				generator.P2D(VIA_DIAMETER + TRACE_SPACING, wrap_multiplier * (OUTER_DIAMETER / 2 + (VIA_DIAMETER + TRACE_SPACING) / 2)),
-				generator.P2D(-(OUTER_DIAMETER - TRACE_WIDTH - TRACE_SPACING) / 2, 0),
-				TRACE_WIDTH,
-				LAYER_INNER[1],
-				not bool(wrap_multiplier + 1)
-			))
-			arcs.extend(generator.arc(
-				generator.P2D(-(OUTER_DIAMETER - TRACE_WIDTH - TRACE_SPACING) / 2, 0),
-				generator.P2D(VIA_DIAMETER + TRACE_SPACING, -wrap_multiplier * (OUTER_DIAMETER / 2 - (TRACE_WIDTH + TRACE_SPACING) / 2)),
-				generator.P2D((OUTER_DIAMETER - TRACE_WIDTH - TRACE_SPACING) / 2, 0),
-				TRACE_WIDTH,
-				LAYER_INNER[1],
-				not bool(wrap_multiplier + 1)
-			))
-
-			# add back top/bottom layers
+		#generate all full turns for one layer
+		for _ in range(N_TURNS):
 			arcs.extend(generator.loop(
-				current_radius,
-				increment,
-				TRACE_WIDTH,
-				LAYER_TOP,
-				wrap_multiplier
-			))
-
-			arcs.extend(generator.loop(
-				current_radius,
-				increment,
-				TRACE_WIDTH,
-				LAYER_BOTTOM,
-				-wrap_multiplier
-			))
-		else:
-			arcs.extend(generator.loop(
-				current_radius,
-				increment,
-				TRACE_WIDTH,
-				LAYER_TOP,
-				wrap_multiplier
-			))
-
-			if LAYER_COUNT > 1:
-				arcs.extend(generator.loop(
 					current_radius,
 					increment,
 					TRACE_WIDTH,
-					LAYER_BOTTOM,
-					-wrap_multiplier
+					layer_names[layer],
+					wrap_direction_multiplier * inverse_turn_mult
 				))
-
-			if LAYER_COUNT > 2:
-				arcs.extend(generator.loop(
-					current_radius,
-					increment,
-					TRACE_WIDTH,
-					LAYER_INNER[0],
-					-wrap_multiplier
-				))
-
-				arcs.extend(generator.loop(
-					current_radius,
-					increment,
-					TRACE_WIDTH,
-					LAYER_INNER[1],
-					wrap_multiplier
-				))
-
-		current_radius += increment
+			current_radius += increment
 
 	# draw breakout line(s)
 	lines.append(
 		generator.line(
 			generator.P2D(current_radius, 0),
-			generator.P2D(current_radius, BREAKOUT_LEN * -wrap_multiplier),
+			generator.P2D(current_radius, BREAKOUT_LEN * -wrap_direction_multiplier),
 			TRACE_WIDTH,
 			LAYER_TOP
 		)
 	)
 	lines.append(
 		generator.line(
-			generator.P2D(current_radius, BREAKOUT_LEN * -wrap_multiplier),
-			generator.P2D(current_radius + BREAKOUT_LEN, BREAKOUT_LEN * -wrap_multiplier),
+			generator.P2D(current_radius, BREAKOUT_LEN * -wrap_direction_multiplier),
+			generator.P2D(current_radius + BREAKOUT_LEN, BREAKOUT_LEN * -wrap_direction_multiplier),
 			TRACE_WIDTH,
 			LAYER_TOP
 		)
@@ -281,15 +147,15 @@ def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, V
 		lines.append(
 			generator.line(
 				generator.P2D(current_radius, 0),
-				generator.P2D(current_radius, BREAKOUT_LEN * wrap_multiplier),
+				generator.P2D(current_radius, BREAKOUT_LEN * wrap_direction_multiplier),
 				TRACE_WIDTH,
 				LAYER_BOTTOM
 			)
 		)
 		lines.append(
 			generator.line(
-				generator.P2D(current_radius, BREAKOUT_LEN * wrap_multiplier),
-				generator.P2D(current_radius + BREAKOUT_LEN, BREAKOUT_LEN * wrap_multiplier),
+				generator.P2D(current_radius, BREAKOUT_LEN * wrap_direction_multiplier),
+				generator.P2D(current_radius + BREAKOUT_LEN, BREAKOUT_LEN * wrap_direction_multiplier),
 				TRACE_WIDTH,
 				LAYER_BOTTOM
 			)
@@ -304,7 +170,7 @@ def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, V
 	pads.append(
 		generator.pad(
 			1,
-			generator.P2D(current_radius + 1.7 * BREAKOUT_LEN, BREAKOUT_LEN * -wrap_multiplier),
+			generator.P2D(current_radius + 1.7 * BREAKOUT_LEN, BREAKOUT_LEN * -wrap_direction_multiplier),
 			8 * TRACE_WIDTH,
 			TRACE_WIDTH,
 			LAYER_TOP
@@ -315,7 +181,7 @@ def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, V
 		pads.append(
 			generator.pad(
 				2,
-				generator.P2D(current_radius + 1.7 * BREAKOUT_LEN, BREAKOUT_LEN * wrap_multiplier),
+				generator.P2D(current_radius + 1.7 * BREAKOUT_LEN, BREAKOUT_LEN * wrap_direction_multiplier),
 				8 * TRACE_WIDTH,
 				TRACE_WIDTH,
 				LAYER_BOTTOM

--- a/plugins/lib/coilgenerator.py
+++ b/plugins/lib/coilgenerator.py
@@ -62,8 +62,8 @@ def generate(layer_count, wrap_clockwise, turns_per_layer, trace_width, trace_sp
 	lines = []
 	pads = []
 
-	VIA_INSIDE_RADIUS = outer_diameter / 2 - turns_per_layer * trace_width - (turns_per_layer + 2) * trace_spacing - via_diameter - trace_width / 2
-	VIA_OUTSIDE_RADIUS = outer_diameter / 2 + via_diameter + trace_spacing + trace_spacing + trace_width
+	VIA_INSIDE_RADIUS = outer_diameter / 2 - turns_per_layer * trace_width - (turns_per_layer -1) * trace_spacing - via_diameter - (trace_width + trace_spacing)
+	VIA_OUTSIDE_RADIUS = outer_diameter / 2 + via_diameter + 2 * trace_spacing + trace_width
 
 	#calculate the number of vias inside and outside of coil and their corresponding degree spacing
 	num_vias_inside = 0

--- a/plugins/lib/coilgenerator.py
+++ b/plugins/lib/coilgenerator.py
@@ -22,13 +22,25 @@ import math
 from . import generator
 
 TEMPLATE_FILE = "../dynamic/template.kicad_mod"
-LAYER_TOP = "F.Cu"
-LAYER_BOTTOM = "B.Cu"
-LAYER_INNER = ["In1.Cu", "In2.Cu"]
-
 BREAKOUT_LEN = 0.5  # (mm)
 
-def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, VIA_DIAMETER, VIA_DRILL, OUTER_DIAMETER, NAME, layer_names):
+def generate(layer_count, wrap_clockwise, turns_per_layer, trace_width, trace_spacing, via_diameter, via_drill, outer_diameter, coil_name, layer_names):
+	"""
+	Generates coils with given parameters. Attempts to place all parts to generate valid coils, though with some parameters, producing a valid coil might not be possible
+	Args:
+		layer_count: Number of layers in coil
+		wrap_clockwise: Clockwise or counter-clockwise coil wrapping
+		turns_per_layer: Minimum number of turns per layer: Connecting to vias might introduce up to one more turn
+		trace_width: Width of line trace
+		trace_spacing: Distance between line traces
+		via_diameter: Outer diameter of connecting vias
+		via_drill: Diameter of via drill hole
+		outer_diameter: Desires outer coil diameter. Coil generation is from outside to inside, so if this is too small, coil wraps may collode
+		coil_name: Reference name of coil to put in kicad
+		layer_names: Names of Kicad layers to place coil in. Lenght is expected to be >= layer_count
+	Returns:
+		File: Generated coil in file
+	"""
 	class Connector:
 		x: float
 		y: float
@@ -50,16 +62,17 @@ def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, V
 	lines = []
 	pads = []
 
-	VIA_INSIDE_RADIUS = OUTER_DIAMETER / 2 - N_TURNS * TRACE_WIDTH - (N_TURNS - 1) * TRACE_SPACING - VIA_DIAMETER - TRACE_WIDTH / 2
-	VIA_OUTSIDE_RADIUS = OUTER_DIAMETER / 2 + VIA_DIAMETER + TRACE_SPACING
+	VIA_INSIDE_RADIUS = outer_diameter / 2 - turns_per_layer * trace_width - (turns_per_layer + 2) * trace_spacing - via_diameter - trace_width / 2
+	VIA_OUTSIDE_RADIUS = outer_diameter / 2 + via_diameter + trace_spacing + trace_spacing + trace_width
 
+	#calculate the number of vias inside and outside of coil and their corresponding degree spacing
 	num_vias_inside = 0
 	num_vias_outside = 0
 
-	if LAYER_COUNT -1 > 0:
-		num_vias_inside = (LAYER_COUNT -1) // 2
+	if layer_count -1 > 0:
+		num_vias_inside = (layer_count -1) // 2
 		num_vias_outside = num_vias_inside
-		if (LAYER_COUNT -1) % 2 != 0:
+		if (layer_count -1) % 2 != 0:
 			num_vias_inside += 1
 
 
@@ -71,7 +84,7 @@ def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, V
 	arc_connectors = []
 
 	# generating layer - 1 vias
-	for v in range(0, LAYER_COUNT-1):
+	for v in range(0, layer_count-1):
 
 		# define if via is placed inside or outside of coil
 		via_used_radius = VIA_INSIDE_RADIUS
@@ -96,17 +109,17 @@ def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, V
 		vias.append(
 			generator.via(
 				generator.P2D(width, height),
-				VIA_DIAMETER,
-				VIA_DRILL
+				via_diameter,
+				via_drill
 			)
 		)
 
 	# build out arcs to spec, until # turns is reached
-	wrap_direction_multiplier = 1 if WRAP_CLOCKWISE else -1
-	increment = TRACE_WIDTH + TRACE_SPACING
+	wrap_direction_multiplier = 1 if wrap_clockwise else -1
+	increment = trace_width + trace_spacing
 
-	start_radius = OUTER_DIAMETER / 2 - N_TURNS * TRACE_WIDTH - (N_TURNS - 1) * TRACE_SPACING
-	for layer in range(LAYER_COUNT):
+	start_radius = outer_diameter / 2 - turns_per_layer * trace_width - (turns_per_layer - 1) * trace_spacing
+	for layer in range(layer_count):
 		current_radius = start_radius
 
 		# for odd layers, the wrap direction needs to be flipped
@@ -115,49 +128,93 @@ def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, V
 			inverse_turn_mult = -1
 
 		#generate all full turns for one layer
-		for _ in range(N_TURNS):
+		for _ in range(turns_per_layer):
 			arcs.extend(generator.loop(
 					current_radius,
 					increment,
-					TRACE_WIDTH,
+					trace_width,
 					layer_names[layer],
 					wrap_direction_multiplier * inverse_turn_mult
 				))
 			current_radius += increment
 
+		# connect to vias
+		if layer % 2 == 0:
+			first_via_inside = False
+			second_via_inside = True
+		else:
+			first_via_inside = True
+			second_via_inside = False
+
+		if (wrap_clockwise and layer % 2 == 0) \
+			or (not wrap_clockwise and layer % 2 == 1):
+			current_clockwise = True
+		else:
+			current_clockwise = False
+
+		loop_inner_point = generator.P2D(start_radius, 0)
+		loop_outer_point = generator.P2D(current_radius, 0)
+
+		# connect up to two vias, or one for first and last layer
+		if layer > 0:
+			if first_via_inside:
+				loop_end_point = loop_inner_point
+				end_point_radius = start_radius
+			else:
+				loop_end_point = loop_outer_point
+				end_point_radius = current_radius
+
+			(arcs, lines) = connect_via(end_point_radius, loop_end_point, increment, layer_names[layer], trace_width, first_via_inside, current_clockwise, arc_connectors[layer -1], arcs, lines)
+
+		if layer < layer_count -1:
+			if second_via_inside:
+				loop_end_point = loop_inner_point
+				end_point_radius = start_radius
+			else:
+				loop_end_point = loop_outer_point
+				end_point_radius = current_radius
+
+			(arcs, lines) = connect_via(end_point_radius, loop_end_point, increment, layer_names[layer], trace_width, second_via_inside, current_clockwise, arc_connectors[layer], arcs, lines)
+
+	top_pad_center_point = generator.P2D(current_radius + BREAKOUT_LEN + 4 * trace_width, (BREAKOUT_LEN + 0.5 * via_diameter) * -wrap_direction_multiplier)
+	bottom_pad_center_point = generator.P2D(current_radius + BREAKOUT_LEN + 4 * trace_width, (BREAKOUT_LEN + 0.5 * via_diameter)* wrap_direction_multiplier)
+
 	# draw breakout line(s)
+
 	lines.append(
 		generator.line(
 			generator.P2D(current_radius, 0),
-			generator.P2D(current_radius, BREAKOUT_LEN * -wrap_direction_multiplier),
-			TRACE_WIDTH,
-			LAYER_TOP
-		)
-	)
-	lines.append(
-		generator.line(
-			generator.P2D(current_radius, BREAKOUT_LEN * -wrap_direction_multiplier),
-			generator.P2D(current_radius + BREAKOUT_LEN, BREAKOUT_LEN * -wrap_direction_multiplier),
-			TRACE_WIDTH,
-			LAYER_TOP
+			generator.P2D(current_radius, top_pad_center_point.y),
+			trace_width,
+			layer_names[0]
 		)
 	)
 
-	if LAYER_COUNT > 1:
+	lines.append(
+		generator.line(
+			generator.P2D(current_radius, top_pad_center_point.y),
+			top_pad_center_point,
+			trace_width,
+			layer_names[0]
+		)
+	)
+
+	if layer_count > 1:
 		lines.append(
 			generator.line(
 				generator.P2D(current_radius, 0),
-				generator.P2D(current_radius, BREAKOUT_LEN * wrap_direction_multiplier),
-				TRACE_WIDTH,
-				LAYER_BOTTOM
+				generator.P2D(current_radius, bottom_pad_center_point.y),
+				trace_width,
+				layer_names[layer_count -1]
 			)
 		)
+
 		lines.append(
 			generator.line(
-				generator.P2D(current_radius, BREAKOUT_LEN * wrap_direction_multiplier),
-				generator.P2D(current_radius + BREAKOUT_LEN, BREAKOUT_LEN * wrap_direction_multiplier),
-				TRACE_WIDTH,
-				LAYER_BOTTOM
+				generator.P2D(current_radius, bottom_pad_center_point.y),
+				bottom_pad_center_point,
+				trace_width,
+				layer_names[layer_count -1]
 			)
 		)
 
@@ -170,26 +227,26 @@ def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, V
 	pads.append(
 		generator.pad(
 			1,
-			generator.P2D(current_radius + 1.7 * BREAKOUT_LEN, BREAKOUT_LEN * -wrap_direction_multiplier),
-			8 * TRACE_WIDTH,
-			TRACE_WIDTH,
-			LAYER_TOP
+			top_pad_center_point,
+			8 * trace_width,
+			trace_width,
+			layer_names[0]
 		)
 	)
 
-	if LAYER_COUNT > 1:
+	if layer_count > 1:
 		pads.append(
 			generator.pad(
 				2,
-				generator.P2D(current_radius + 1.7 * BREAKOUT_LEN, BREAKOUT_LEN * wrap_direction_multiplier),
-				8 * TRACE_WIDTH,
-				TRACE_WIDTH,
-				LAYER_BOTTOM
+				bottom_pad_center_point,
+				8 * trace_width,
+				trace_width,
+				layer_names[layer_count -1]
 			)
 		)
 
 	substitution_dict = {
-		"NAME": NAME,
+		"NAME": coil_name,
 		"LINES": ''.join(lines),
 		"ARCS": ''.join(arcs),
 		"VIAS": ''.join(vias),
@@ -200,3 +257,209 @@ def generate(LAYER_COUNT, WRAP_CLOCKWISE, N_TURNS, TRACE_WIDTH, TRACE_SPACING, V
 	}
 
 	return template.format(**substitution_dict)
+
+def get_circle_section_centerpoint(point_a, point_b, radius):
+	"""
+	Takes two points A and B, generates a point central to A and B and places it on a radius from origin
+	Args:
+		point_a: Reference point A to produce central point from
+		point_b: Reference point B to produce central point from
+		radius: Desired radius at which to put produced point
+
+	Returns:
+		P2D: Generated center point between A and B on radius
+	"""
+	point_a_red = get_point_radius_reduced(point_a, 1)
+	point_b_red = get_point_radius_reduced(point_b, 1)
+
+	x_new = (point_a_red.x + point_b_red.x) / 2
+	y_new = (point_a_red.y + point_b_red.y) / 2
+
+	angle_deg = math.atan2(x_new, y_new) * 180 / math.pi
+	return get_point_on_circle(angle_deg, radius)
+
+def get_angle_degree_of_point(point):
+	"""
+	Takes a point, and calculates angle from it, at which it would sit on a generated circle around origin
+	Args:
+		point: Point of which to get angle around origin circle
+
+	Returns:
+		float: Angle in degree of point on origin circle
+	"""
+	angle_rad = math.atan2(point.x, point.y)
+	return angle_rad * 180 / math.pi
+
+def get_point_on_circle(angle_deg, radius):
+	"""
+	Given an angle and a radius, generates a point on the resulting circle
+	Args:
+		angle_deg: Angle in degree, at which to position point on circle
+		radius: Radius of target circle
+
+	Returns:
+		P2D: given point on circle at angle_deg
+	"""
+	a = math.cos(math.radians(angle_deg)) * radius
+	b = math.sin(math.radians(angle_deg)) * radius
+	return generator.P2D(b, a)
+
+def get_point_radius_reduced(point, radius):
+	"""
+	Reduces a point to be on a circle with given radius around the origin
+	Args:
+		point: Point somewhere outside of circle
+		radius: Radius of target circle
+
+	Returns:
+		P2D: given point, mapped onto circle with radius
+	"""
+	hypotenuse = math.sqrt(point.x**2 + point.y**2)
+	factor = hypotenuse / radius
+	return generator.P2D(point.x / factor, point.y / factor)
+
+def get_point_distance(point_a, point_b):
+	"""
+	Returns the distance between two points
+	Args:
+		point_a: Start point
+		point_b: End point
+
+	Returns:
+		float: Distance between given points
+	"""
+	return math.sqrt((point_a.x - point_b.x)**2 + (point_a.y - point_b.y)**2)
+
+def get_angle_degree_between(point_a, point_b, clockwise):
+	"""
+	Returns angle difference between two points on a circle, factoring in traversing direction
+	Args:
+		point_a: Start point
+		point_b: End point
+		clockwise: Traversal direction
+
+	Returns:
+		float: Angle in degree, between the given points
+	"""
+	angle_a = get_angle_degree_of_point(point_a)
+	if angle_a < 0:
+		angle_a = 360 + angle_a
+	angle_b = get_angle_degree_of_point(point_b)
+	if angle_b < 0:
+		angle_b = 360 + angle_b
+
+	result = angle_a - angle_b
+	if result < 0:
+		result = 360 + result
+
+	if not clockwise:
+		result = 360 - result
+
+	if result == 360:
+		result = 0
+
+	return result
+
+def is_left_of(point_a, point_b):
+	"""
+	Checks if point a is left of point b
+	Convenience function to be more expressive
+	Args:
+		point_a: Point A to check if A left of B
+		point_b: Point B to check if A left of B
+		clockwise: Traversal direction
+
+	Returns:
+		float: Angle in degree, between the given points
+	"""
+	return point_a < point_b
+
+def connect_via(end_point_radius, loop_end_point, loop_increment, layer_name, trace_width, inside, clockwise, arc_connector, arcs, lines):
+	"""
+	Connects a coil spirals endpoint to a designated via.
+	Does so in three steps:
+	1) If the distance between the end point and via is >= 180 degree in coil winding direction, produces a half arc.
+	2) If the distance is then still greater than 3 * loop_increment, generates a partial arc to fill the gap
+	3) Connects the last missing piece via a straight line
+	Args:
+		end_point_radius: Radius of loop_end_point
+		loop_end_point: Edge of coil spiral to connect to via
+		loop_increment:
+		layer_name: Name of currently modified layer, needed for line generation
+		trace_width: Width of the line trace
+		inside: Boolean to identify if inside of a coil spiral is to be connected or outside
+		clockwise: Boolean to identify if the coil spiral is going clockwise or counter-clockwise (check from outside end point)
+		arc_connector: Via to connect to
+		arcs: Previously drawn arcs array to manipulate / append
+		lines: previously drawn lines array to manipulate / append
+	Returns:
+		([str], [str]): Modified (arcs array, lines array)
+	"""
+	MIN_DIRECT_BRIDGE_DISTANCE = (3 * loop_increment)
+
+	# define which endpoint is on outer side of loop and which on inner side
+	if inside :
+		target_radius_closest_to_via = end_point_radius - loop_increment
+	else:
+		target_radius_closest_to_via = end_point_radius + loop_increment
+
+	current_closest_to_via_radius = end_point_radius
+	current_closest_to_via = loop_end_point
+
+	# define a point close to the via from where to go straight to the via
+	nearest_connector_point = get_point_radius_reduced(generator.P2D(arc_connector.x, arc_connector.y), target_radius_closest_to_via)
+	# if the via is too far away from one of the loop endpoints, the gap needs to be bridged
+	if get_point_distance(current_closest_to_via, generator.P2D(arc_connector.x, arc_connector.y)) >= MIN_DIRECT_BRIDGE_DISTANCE:
+
+		# if more than half a circle is to cover, split the operation in generating half a circle + the rest
+		if get_angle_degree_between(current_closest_to_via, nearest_connector_point, (inside == clockwise)) >= 180:
+			# radius adaption
+			if inside:
+				arc_target_radius = target_radius_closest_to_via
+				arc_center_radius = arc_target_radius + 0.5 * loop_increment
+			else:
+				arc_target_radius = target_radius_closest_to_via - loop_increment
+				arc_center_radius = arc_target_radius
+
+			# for half circle, opposite point is end point
+			opposite_point = get_point_radius_reduced(generator.P2D(-loop_end_point.x, -loop_end_point.y), arc_target_radius)
+
+			center_point = generator.P2D(0, arc_center_radius)
+			if inside != clockwise:
+				center_point.y = center_point.y * -1
+
+			arcs.extend(generator.arc(
+				loop_end_point,
+				center_point,
+				opposite_point,
+				trace_width,
+				layer_name,
+				not (clockwise == inside)))
+
+			current_closest_to_via = opposite_point
+			current_closest_to_via_radius = arc_target_radius
+
+		# if 180 degree arc was not enough, the gap needs to fill with a partial arc
+		remaining_angle = get_angle_degree_between(current_closest_to_via, nearest_connector_point,  (inside == clockwise))
+
+		if remaining_angle >= MIN_DIRECT_BRIDGE_DISTANCE:
+			arc_center_radius = (target_radius_closest_to_via - current_closest_to_via_radius) / 2 + current_closest_to_via_radius
+
+			arcs.extend(generator.arc(
+				current_closest_to_via,
+				get_circle_section_centerpoint(current_closest_to_via, nearest_connector_point, arc_center_radius),
+				nearest_connector_point,
+				trace_width,
+				layer_name,
+				not (inside == clockwise)))
+
+			current_closest_to_via = nearest_connector_point
+
+	# connecting the last piece to via with direct line
+	lines.extend(generator.line(
+		current_closest_to_via,
+		generator.P2D(arc_connector.x, arc_connector.y),
+		trace_width,
+		layer_name))
+
+	return (arcs, lines)

--- a/plugins/lib/menu.py
+++ b/plugins/lib/menu.py
@@ -8,13 +8,12 @@ structure = [
 		"unit" : None
 	},{
         "id" : "layer_count",
-		"type" : "choices",
+		"type" : "choices_from_board",
 		"label" : "layer count",
-		"choices" : ["1 layer", "2 layers", "4 layers"],
-        "choices_data" : [1, 2, 4],
-		"default" : 0,
+        "choices_source" : "COPPER_LAYER_COUNT",
+        "default" : 1,
         "datatype" : "int",
-		"unit" : None
+		"unit" : "layer"
 	},{
         "id" : "turns_count",
 		"type" : "text",

--- a/plugins/plugin.py
+++ b/plugins/plugin.py
@@ -383,15 +383,6 @@ class CoilGeneratorUI(wx.Frame):
 def get_safe_name(name, keepcharacters = (' ','.','_')):
     return "".join(c for c in name if c.isalnum() or c in keepcharacters).rstrip()
 
-# use this class to track the last focused page
-class FocusTracker(wx.EvtHandler):
-	def __init__(self):
-		wx.EvtHandler.__init__(self)
-		self.prev_focused_window = None
-
-	def OnFocus(self, event):
-		self.prev_focused_window = event.GetEventObject()
-
 # Plugin definition
 class Plugin(pcbnew.ActionPlugin):
 	def __init__(self):
@@ -402,12 +393,8 @@ class Plugin(pcbnew.ActionPlugin):
 		self.show_toolbar_button = True
 		self.icon_file_name = os.path.join(os.path.dirname(__file__), 'icon.png')
 		self.dark_icon_file_name = os.path.join(os.path.dirname(__file__), 'icon.png')
-
-		self.focus_tracker = FocusTracker()
-
-		# if a window loses focus, this event updates the last focused window
-		for window in wx.GetTopLevelWindows():
-			window.Bind(wx.EVT_SET_FOCUS, self.focus_tracker.OnFocus)
 			
 	def Run(self):
-		CoilGeneratorUI(self.focus_tracker.prev_focused_window).Show()
+		# Assuming the PCBNew window is focused when run function is executed
+		# Alternative would be to keep track of last focussed window, which does not seem to work on all systems
+		CoilGeneratorUI(wx.Window.FindFocus()).Show()

--- a/plugins/plugin.py
+++ b/plugins/plugin.py
@@ -365,11 +365,8 @@ class CoilGeneratorUI(wx.Frame):
 			evt.SetKeyCode(ord('V'))
 			evt.SetControlDown(True)
 			self.logger.log(logging.INFO, "Using wx.KeyEvent for paste")
-	
-			wnd = [i for i in self._pcbnew_frame.Children if i.ClassName == 'wxWindow'][0]
-
-			self.logger.log(logging.INFO, "Injecting event: {} into window: {}".format(evt, wnd))
-			wx.PostEvent(wnd, evt)
+		
+			wx.PostEvent(self._pcbnew_frame, evt)
 		except:
 			# Likely on Linux with old wx python support :(
 			self.logger.log(logging.INFO, "Using wx.UIActionSimulator for paste")

--- a/plugins/plugin.py
+++ b/plugins/plugin.py
@@ -245,6 +245,7 @@ class CoilGeneratorUI(wx.Frame):
 		self.Destroy()
 
 		self.logger.log(logging.INFO, "Generating coil ...")
+		layer_names = [pcbnew.GetBoard().GetLayerName(x) for x in range(pcbnew.GetBoard().GetCopperLayerCount())]
 
 		template = coilgenerator.generate(
 			self._parse_data("layer_count"),
@@ -255,7 +256,8 @@ class CoilGeneratorUI(wx.Frame):
 			self._parse_data("via_outer"),
 			self._parse_data("via_drill"),
 			self._parse_data("outer_diameter"),
-			self._parse_data("name")
+			self._parse_data("name"),
+			layer_names
 		)
 
 		self.logger.log(logging.INFO, "Done.")

--- a/plugins/plugin.py
+++ b/plugins/plugin.py
@@ -49,7 +49,16 @@ class CoilGeneratorUI(wx.Frame):
 		self._prepare_defaults_from_cached_settings(menu.structure)
 
 		for entry in menu.structure:
-			if entry["type"] == "choices":
+			if entry["type"] == "choices" or entry["type"] == "choices_from_board":
+
+				# if choice structure values are sourced from board variables, some fields need to be dynamically generated before applying general choice handling
+				if entry["type"] == "choices_from_board":
+					if entry["choices_source"] == "COPPER_LAYER_COUNT":
+						entries_str = [str(e) for e in range(1, pcbnew.GetBoard().GetCopperLayerCount()+1)]
+						entries = [e for e in range(1, pcbnew.GetBoard().GetCopperLayerCount()+1)]
+						entry["choices"] = entries_str
+						entry["choices_data"] = entries
+
 				entry["wx_elem"] = self._make_choices(entry["label"], entry["choices"], entry["default"], entry["unit"])
 				self.Bind(wx.EVT_CHOICE, self._on_choice_change, entry["wx_elem"])
 				self.logger.log(logging.DEBUG, "[UI] Adding Choices")
@@ -187,7 +196,7 @@ class CoilGeneratorUI(wx.Frame):
 
 			val = None
 
-			if entry["type"] == "choices":
+			if entry["type"] == "choices" or entry["type"] == "choices_from_board":
 				val = entry["choices_data"][entry["wx_elem"].GetSelection()]
 			elif entry["type"] == "checkbox":
 				val = entry["wx_elem"].GetValue()

--- a/plugins/plugin.py
+++ b/plugins/plugin.py
@@ -406,7 +406,10 @@ class CoilGeneratorUI(wx.Frame):
 		try:
 			self.elem_button_generate.Enable()
 			self.elem_button_save.Enable()
-			if not self.estimate_is_coil_generatable(
+
+			if self._parse_data("via_outer") < self._parse_data("via_drill"):
+				self.notes.SetLabel("WARNING: Via drill is greater than outer diameter")
+			elif not self.estimate_is_coil_generatable(
 				self._parse_data("outer_diameter"),
 				self._parse_data("turns_count"),
 				self._parse_data("trace_width"),

--- a/plugins/plugin.py
+++ b/plugins/plugin.py
@@ -262,6 +262,8 @@ class CoilGeneratorUI(wx.Frame):
 
 		self.logger.log(logging.INFO, "Generating coil ...")
 		layer_names = [pcbnew.GetBoard().GetLayerName(x) for x in range(pcbnew.GetBoard().GetCopperLayerCount())]
+		# last layer in layer list should always be B.Cu, but if board layer count != max_layer_count, pcbnew reports InX.Cu as last layer name
+		layer_names[pcbnew.GetBoard().GetCopperLayerCount() -1] = "B.Cu"
 
 		template = coilgenerator.generate(
 			self._parse_data("layer_count"),


### PR DESCRIPTION
# What this does

- Rewrote generate-Function to
    - be more modular 
    - be (hopefully) better maintainable and extendable for other coil geometries
    - support any number of layers

- Enhanced UI to
    - Make generatable coil layer numbers dependent on board setup
    - Added warning when an estimation determines that a generated coil MIGHT be broken
    - Added warning for when input fields contain invalid values
    - Added warning for when via drill diameter is bigger than via outside diameter

- Less hardcoded values, like
    -  board layer names are now pulled from PCBNew

# Significant changes:

- In previous version of coil generator, the lower coil layer was always B.Cu, no matter the board stackup. This version generates coil layers starting from F.Cu downwards without skipping layers
- Via connection is now done with a trace parallel to the radius line, instead of curved connection directly to via, to prevent collision with other vias for coils with high layer number 
- Coils with uneven layer number are now supported. These coils will only receive one pad. The other connection can then be done with a "endpoint"-via inside the coil