### PR TITLE
fixed drc error on one layer coils

### DIFF
--- a/plugins/dynamic/template.kicad_mod
+++ b/plugins/dynamic/template.kicad_mod
@@ -41,6 +41,6 @@
 		)
 	)
 	(zone_connect 2)
-	(net_tie_pad_groups "0, 1, 2")
+	(net_tie_pad_groups "{NET_TIE}")
 	(attr exclude_from_pos_files exclude_from_bom allow_missing_courtyard)
 {LINES}{ARCS}{VIAS}{PADS})

--- a/plugins/lib/coilgenerator.py
+++ b/plugins/lib/coilgenerator.py
@@ -75,6 +75,8 @@ def generate(layer_count, wrap_clockwise, turns_per_layer, trace_width, trace_sp
 		"UUID1": generator.get_uuid(),
 		"UUID2": generator.get_uuid(),
 		"UUID3": generator.get_uuid(),
+		# one-layer coils are missing 0, because 0 is assigned to vias in coilcreator, but the only via in one-layer coils is assigned 2 as it serves as connection pad 2
+		"NET_TIE": "0,1,2" if layer_count > 1 else "1,2"
 	}
 
 	return template.format(**substitution_dict)


### PR DESCRIPTION
Issue #23 states:
Users reported a DRC error on one-layer coils as net_tie_pad_groups got assigned "0,1,2" statically, but one-layer coils do not contain pad 0, as inner via serves as connector pad 2.

This is fixed by adding the NET_TIE variable in the template file and filling it dynamically when also pushing lines, arcs, and others. One layer coils simply do not assign net-tie 0!

Should fix #23 